### PR TITLE
rdap_types: add support for Afnic's remark types.

### DIFF
--- a/rdap_client/test_data/domain/domain_afnic.json
+++ b/rdap_client/test_data/domain/domain_afnic.json
@@ -1,0 +1,1068 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_technical_implementation_guide_0",
+    "icann_rdap_response_profile_0"
+  ],
+  "objectClassName": "domain",
+  "handle": "DOM000000181261-FRNIC",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "AFNI30-FRNIC",
+      "remarks": [
+        {
+          "type": "contact restricted publication",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact obsolete",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact type",
+          "description": [
+            "ORGANIZATION"
+          ]
+        },
+        {
+          "type": "reachable",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "eligibility status",
+          "description": [
+            "NotIdentified"
+          ]
+        },
+        {
+          "type": "registrar name",
+          "description": [
+            "Registry Operations"
+          ]
+        }
+      ],
+      "status": [
+        "associated",
+        "active"
+      ],
+      "port43": "whois.nic.fr",
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "2017-07-18T00:00:00Z"
+        },
+        {
+          "eventAction": "last changed",
+          "eventDate": "2018-02-22T08:22:26Z"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/entity/AFNI30-FRNIC",
+          "value": "https://rdap.nic.fr/entity/AFNI30-FRNIC",
+          "rel": "self"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "ASS FRANC NOMMAGE INTERNET EN COOP"
+          ],
+          [
+            "org",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              "Internet en Cooperation2, rue StephensonMontigny le Bretonneux",
+              "Saint Quentin en Yveline",
+              "",
+              "78181",
+              "FR"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "contact@nic.fr"
+          ],
+          [
+            "tel",
+            {},
+            "text",
+            "+33.139308300"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "text",
+            "+33.139308301"
+          ]
+        ]
+      ],
+      "roles": [
+        "registrant"
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "RAR939-FRNIC",
+      "remarks": [
+        {
+          "type": "registrar restricted publication",
+          "description": [
+            "No"
+          ]
+        }
+      ],
+      "status": [
+        "active"
+      ],
+      "port43": "whois.nic.fr",
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "2014-07-29T15:35:33Z"
+        },
+        {
+          "eventAction": "last changed",
+          "eventDate": "2022-10-12T18:54:01.785057Z"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+          "value": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+          "rel": "self"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Registry Operations"
+          ],
+          [
+            "tel",
+            {},
+            "text",
+            "+33.139308300"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "text",
+            "+33.139308301"
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "support@afnic.fr"
+          ],
+          [
+            "url",
+            {},
+            "uri",
+            "https://www.afnic.fr"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              [
+                "AFNIC",
+                "immeuble le Stephenson",
+                "1, rue Stephenson"
+              ],
+              "Montigny-Le-Bretonneux",
+              "",
+              "78180",
+              "FR"
+            ]
+          ]
+        ]
+      ],
+      "roles": [
+        "registrar",
+        "sponsor"
+      ],
+      "publicIds": [
+        {
+          "type": "IANA Registrar ID",
+          "identifier": "9999"
+        }
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "DC7-FRNIC",
+      "remarks": [
+        {
+          "type": "contact restricted publication",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact obsolete",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact type",
+          "description": [
+            "PERSON"
+          ]
+        },
+        {
+          "type": "reachable",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "eligibility status",
+          "description": [
+            "NotIdentified"
+          ]
+        },
+        {
+          "type": "registrar name",
+          "description": [
+            "Registry Operations"
+          ]
+        }
+      ],
+      "status": [
+        "associated",
+        "active"
+      ],
+      "port43": "whois.nic.fr",
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "2000-10-24T00:00:00Z"
+        },
+        {
+          "eventAction": "last changed",
+          "eventDate": "2022-09-28T11:20:41Z"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/entity/DC7-FRNIC",
+          "value": "https://rdap.nic.fr/entity/DC7-FRNIC",
+          "rel": "self"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "David Chansard David"
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "AFNIC"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              [
+                "immeuble le Stephenson",
+                "1, rue Stephenson",
+                "Hall A2 - 3eme etage"
+              ],
+              "Montigny-Le-Bretonneux",
+              "",
+              "78180",
+              "FR"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "david.chansard@nic.fr"
+          ],
+          [
+            "tel",
+            {},
+            "text",
+            "+33.139308353"
+          ]
+        ]
+      ],
+      "roles": [
+        "administrative"
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "VL-FRNIC",
+      "remarks": [
+        {
+          "type": "contact restricted publication",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact obsolete",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact type",
+          "description": [
+            "PERSON"
+          ]
+        },
+        {
+          "type": "reachable",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "eligibility status",
+          "description": [
+            "NotIdentified"
+          ]
+        },
+        {
+          "type": "registrar name",
+          "description": [
+            "Registry Operations"
+          ]
+        }
+      ],
+      "status": [
+        "associated",
+        "active"
+      ],
+      "port43": "whois.nic.fr",
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "2001-04-09T00:00:00Z"
+        },
+        {
+          "eventAction": "last changed",
+          "eventDate": "2019-01-28T16:11:55Z"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/entity/VL-FRNIC",
+          "value": "https://rdap.nic.fr/entity/VL-FRNIC",
+          "rel": "self"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Vincent Levigneron Vincent"
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "AFNIC"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              [
+                "Immeuble Le Stephenson",
+                "1, rue Stephenson"
+              ],
+              "Montigny-le-Bretonneux",
+              "",
+              "78180",
+              "FR"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "vincent.levigneron@afnic.fr"
+          ],
+          [
+            "tel",
+            {},
+            "text",
+            "+33.139308300"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "text",
+            "+33.139308301"
+          ]
+        ]
+      ],
+      "roles": [
+        "technical"
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "JP-FRNIC",
+      "remarks": [
+        {
+          "type": "contact restricted publication",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact obsolete",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "contact type",
+          "description": [
+            "PERSON"
+          ]
+        },
+        {
+          "type": "reachable",
+          "description": [
+            "NO"
+          ]
+        },
+        {
+          "type": "eligibility status",
+          "description": [
+            "NotIdentified"
+          ]
+        },
+        {
+          "type": "registrar name",
+          "description": [
+            "Registry Operations"
+          ]
+        }
+      ],
+      "status": [
+        "associated",
+        "active"
+      ],
+      "port43": "whois.nic.fr",
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "2001-10-02T00:00:00Z"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/entity/JP-FRNIC",
+          "value": "https://rdap.nic.fr/entity/JP-FRNIC",
+          "rel": "self"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Jean-Philippe Pick Jean-Philippe"
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "AFNIC"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              [
+                "immeuble le Stephenson",
+                "1, rue Stephenson",
+                "Hall A2 - 3eme etage"
+              ],
+              "Montigny-Le-Bretonneux",
+              "",
+              "78180",
+              "FR"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "nic@nic.fr"
+          ],
+          [
+            "tel",
+            {},
+            "text",
+            "+33.139308300"
+          ]
+        ]
+      ],
+      "roles": [
+        "technical"
+      ]
+    }
+  ],
+  "status": [
+    "active"
+  ],
+  "port43": "whois.nic.fr",
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "2001-12-10T23:00:00Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2029-07-18T08:26:59Z"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "2022-09-28T11:21:02Z"
+    },
+    {
+      "eventAction": "transfer",
+      "eventDate": "2017-07-18T08:26:59Z"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://rdap.nic.fr/domain/afnic.fr",
+      "value": "https://rdap.nic.fr/domain/afnic.fr",
+      "rel": "self"
+    }
+  ],
+  "ldhName": "afnic.fr",
+  "secureDns": {
+    "delegationSigned": true,
+    "dsData": [
+      {
+        "keyTag": 53080,
+        "algorithm": 13,
+        "digest": "EF2DC0C8CF1FDF2994E8C771E0F871949B83AF41A1BF594B484677F5A85A657B",
+        "digestType": 2
+      }
+    ]
+  },
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "HOST07-FRNIC",
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "handle": "RAR939-FRNIC",
+          "remarks": [
+            {
+              "type": "registrar restricted publication",
+              "description": [
+                "No"
+              ]
+            }
+          ],
+          "status": [
+            "active"
+          ],
+          "port43": "whois.nic.fr",
+          "events": [
+            {
+              "eventAction": "registration",
+              "eventDate": "2014-07-29T15:35:33Z"
+            },
+            {
+              "eventAction": "last changed",
+              "eventDate": "2022-10-12T18:54:01.785057Z"
+            }
+          ],
+          "links": [
+            {
+              "href": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "value": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "rel": "self"
+            }
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Registry Operations"
+              ],
+              [
+                "tel",
+                {},
+                "text",
+                "+33.139308300"
+              ],
+              [
+                "tel",
+                {
+                  "type": "fax"
+                },
+                "text",
+                "+33.139308301"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "support@afnic.fr"
+              ],
+              [
+                "url",
+                {},
+                "uri",
+                "https://www.afnic.fr"
+              ],
+              [
+                "adr",
+                {},
+                "text",
+                [
+                  "",
+                  "",
+                  [
+                    "AFNIC",
+                    "immeuble le Stephenson",
+                    "1, rue Stephenson"
+                  ],
+                  "Montigny-Le-Bretonneux",
+                  "",
+                  "78180",
+                  "FR"
+                ]
+              ]
+            ]
+          ],
+          "roles": [
+            "registrar",
+            "sponsor"
+          ],
+          "publicIds": [
+            {
+              "type": "IANA Registrar ID",
+              "identifier": "9999"
+            }
+          ]
+        }
+      ],
+      "remarks": [
+        {
+          "title": "result set truncated due to authorization",
+          "description": [
+            "The list of results does not contain all results due to lack of authorization.",
+            "This may indicate to some clients that proper authorization will yield a longer result set."
+          ]
+        }
+      ],
+      "status": [
+        "server update prohibited",
+        "server delete prohibited",
+        "associated"
+      ],
+      "port43": "whois.nic.fr",
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/nameserver/ns3.nic.fr",
+          "value": "https://rdap.nic.fr/nameserver/ns3.nic.fr",
+          "rel": "self"
+        }
+      ],
+      "ldhName": "ns3.nic.fr",
+      "ipAddresses": {
+        "v4": [
+          "192.134.0.49"
+        ],
+        "v6": [
+          "2001:660:3006:1::1:1"
+        ]
+      }
+    },
+    {
+      "objectClassName": "nameserver",
+      "handle": "HOST06-FRNIC",
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "handle": "RAR939-FRNIC",
+          "remarks": [
+            {
+              "type": "registrar restricted publication",
+              "description": [
+                "No"
+              ]
+            }
+          ],
+          "status": [
+            "active"
+          ],
+          "port43": "whois.nic.fr",
+          "events": [
+            {
+              "eventAction": "registration",
+              "eventDate": "2014-07-29T15:35:33Z"
+            },
+            {
+              "eventAction": "last changed",
+              "eventDate": "2022-10-12T18:54:01.785057Z"
+            }
+          ],
+          "links": [
+            {
+              "href": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "value": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "rel": "self"
+            }
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Registry Operations"
+              ],
+              [
+                "tel",
+                {},
+                "text",
+                "+33.139308300"
+              ],
+              [
+                "tel",
+                {
+                  "type": "fax"
+                },
+                "text",
+                "+33.139308301"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "support@afnic.fr"
+              ],
+              [
+                "url",
+                {},
+                "uri",
+                "https://www.afnic.fr"
+              ],
+              [
+                "adr",
+                {},
+                "text",
+                [
+                  "",
+                  "",
+                  [
+                    "AFNIC",
+                    "immeuble le Stephenson",
+                    "1, rue Stephenson"
+                  ],
+                  "Montigny-Le-Bretonneux",
+                  "",
+                  "78180",
+                  "FR"
+                ]
+              ]
+            ]
+          ],
+          "roles": [
+            "registrar",
+            "sponsor"
+          ],
+          "publicIds": [
+            {
+              "type": "IANA Registrar ID",
+              "identifier": "9999"
+            }
+          ]
+        }
+      ],
+      "remarks": [
+        {
+          "title": "result set truncated due to authorization",
+          "description": [
+            "The list of results does not contain all results due to lack of authorization.",
+            "This may indicate to some clients that proper authorization will yield a longer result set."
+          ]
+        }
+      ],
+      "status": [
+        "server update prohibited",
+        "server delete prohibited",
+        "associated"
+      ],
+      "port43": "whois.nic.fr",
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/nameserver/ns2.nic.fr",
+          "value": "https://rdap.nic.fr/nameserver/ns2.nic.fr",
+          "rel": "self"
+        }
+      ],
+      "ldhName": "ns2.nic.fr",
+      "ipAddresses": {
+        "v4": [
+          "192.93.0.4"
+        ],
+        "v6": [
+          "2001:660:3005:1::1:2"
+        ]
+      }
+    },
+    {
+      "objectClassName": "nameserver",
+      "handle": "HOST05-FRNIC",
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "handle": "RAR939-FRNIC",
+          "remarks": [
+            {
+              "type": "registrar restricted publication",
+              "description": [
+                "No"
+              ]
+            }
+          ],
+          "status": [
+            "active"
+          ],
+          "port43": "whois.nic.fr",
+          "events": [
+            {
+              "eventAction": "registration",
+              "eventDate": "2014-07-29T15:35:33Z"
+            },
+            {
+              "eventAction": "last changed",
+              "eventDate": "2022-10-12T18:54:01.785057Z"
+            }
+          ],
+          "links": [
+            {
+              "href": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "value": "https://rdap.nic.fr/entity/RAR939-FRNIC",
+              "rel": "self"
+            }
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Registry Operations"
+              ],
+              [
+                "tel",
+                {},
+                "text",
+                "+33.139308300"
+              ],
+              [
+                "tel",
+                {
+                  "type": "fax"
+                },
+                "text",
+                "+33.139308301"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "support@afnic.fr"
+              ],
+              [
+                "url",
+                {},
+                "uri",
+                "https://www.afnic.fr"
+              ],
+              [
+                "adr",
+                {},
+                "text",
+                [
+                  "",
+                  "",
+                  [
+                    "AFNIC",
+                    "immeuble le Stephenson",
+                    "1, rue Stephenson"
+                  ],
+                  "Montigny-Le-Bretonneux",
+                  "",
+                  "78180",
+                  "FR"
+                ]
+              ]
+            ]
+          ],
+          "roles": [
+            "registrar",
+            "sponsor"
+          ],
+          "publicIds": [
+            {
+              "type": "IANA Registrar ID",
+              "identifier": "9999"
+            }
+          ]
+        }
+      ],
+      "remarks": [
+        {
+          "title": "result set truncated due to authorization",
+          "description": [
+            "The list of results does not contain all results due to lack of authorization.",
+            "This may indicate to some clients that proper authorization will yield a longer result set."
+          ]
+        }
+      ],
+      "status": [
+        "server update prohibited",
+        "server delete prohibited",
+        "associated"
+      ],
+      "port43": "whois.nic.fr",
+      "links": [
+        {
+          "href": "https://rdap.nic.fr/nameserver/ns1.nic.fr",
+          "value": "https://rdap.nic.fr/nameserver/ns1.nic.fr",
+          "rel": "self"
+        }
+      ],
+      "ldhName": "ns1.nic.fr",
+      "ipAddresses": {
+        "v4": [
+          "192.134.4.1"
+        ],
+        "v6": [
+          "2001:67c:2218:2::4:1"
+        ]
+      }
+    }
+  ]
+}

--- a/rdap_types/src/lib.rs
+++ b/rdap_types/src/lib.rs
@@ -640,6 +640,27 @@ pub enum NoticeOrRemarkType {
     #[serde(rename = "response truncated due to authorization")]
     /// Non standard value from 'abudhabi' domain registry.
     ResponseTruncatedDueToAuthorization,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "registrar restricted publication")]
+    RegistrarRestrictedPublication,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "contact restricted publication")]
+    ContactRestrictedPublication,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "contact obsolete")]
+    ContactObsolete,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "contact type")]
+    ContactType,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "reachable")]
+    Reachable,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "eligibility status")]
+    EligibilityStatus,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "registrar name")]
+    RegistrarName,
 }
 
 impl<'de> Deserialize<'de> for NoticeOrRemarkType {
@@ -1220,6 +1241,12 @@ mod tests {
     fn test_parse_domain_24() {
         let parsed: Domain = deserialize_and_serialize("domain/domain_24.json");
         assert_eq!("XXXX", parsed.handle.unwrap());
+    }
+
+    #[test]
+    fn test_parse_domain_afnic() {
+        let parsed: Domain = deserialize_and_serialize("domain/domain_afnic.json");
+        assert_eq!("DOM000000181261-FRNIC", parsed.handle.unwrap());
     }
 
     #[test]

--- a/rdap_types/src/lib.rs
+++ b/rdap_types/src/lib.rs
@@ -656,6 +656,21 @@ pub enum NoticeOrRemarkType {
     #[serde(rename = "reachable")]
     Reachable,
     /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "reach medium")]
+    ReachMedium,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "reach date")]
+    ReachDate,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "reach source")]
+    ReachSource,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "eligibility date")]
+    EligibilityDate,
+    /// Non standard values from Afnic (fr, etc.) registry
+    #[serde(rename = "eligibility source")]
+    EligibilitySource,
+    /// Non standard values from Afnic (fr, etc.) registry
     #[serde(rename = "eligibility status")]
     EligibilityStatus,
     /// Non standard values from Afnic (fr, etc.) registry


### PR DESCRIPTION
For example check https://rdap.nic.fr/domain/afnic.fr